### PR TITLE
Add Parallel Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 ## Desktop Apps
 
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions
+- [Parallel Code](https://github.com/johannesjo/parallel-code) - Open-source desktop app for running Claude Code, Codex CLI, Gemini CLI, and other terminal coding agents in parallel, with isolated git worktrees, terminal panes, diff review, and merge controls.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adds Parallel Code to the desktop apps section.

Parallel Code is a free, MIT-licensed desktop app for running terminal-based coding agents such as Claude Code, Codex CLI, and Gemini CLI in parallel. Each task runs in its own Git branch and worktree, with terminal panes, diff review, and merge controls.