### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [aider](https://aider.chat/) - AI pair programming in your terminal.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - Small Bash helper for switching Codex CLI/Desktop accounts with isolated `CODEX_HOME` profiles.
 
 - [claude-dash](https://github.com/krabat-l/claude-dash) - Real-time statusline for Claude Code showing context, cost, quota, cache, tools, and git status.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - Local TUI for inspecting AI coding-agent session logs, usage, cost, latency, tool failures, diffs, and CI gates.


### PR DESCRIPTION
Adds codex-profiles, a small Bash utility for switching Codex CLI/Desktop profiles with isolated CODEX_HOME directories.

I think it fits this resource list because the Command Line Tools section already includes local AI coding-agent helpers and Codex-compatible workflow tools such as Agent FM, MUSE, SwarmClaw, SwarmVault, and agenttrace. codex-profiles supports the same command-line workflow by keeping Codex account state isolated across contexts.

Install:
```sh
brew install Ducksss/tap/codex-profile
```

Repo: https://github.com/Ducksss/codex-profiles