### PR TITLE
Add Primio

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 ## Mobile-first Tools
 
 - [Vibecode](https://www.vibecodeapp.com/) - "the mobile app that builds mobile apps".
+- [Primio](https://primio.dev/) - chat-based builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds Primio to Mobile-first Tools.

[Primio](https://primio.dev/) is a chat-based builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.