### PR TITLE
Add Wikivibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [CodeGuide](https://www.codeguide.dev/) - Creates detailed Documentation for your AI Coding Projects.
 - [LegacyDoc AI](https://www.romanticode.com/legacydoc-ai/) - VS Code extension that generates documentation, architecture maps, and AI-ready context packs for vibe-coded codebases.
 - [vibeprompt](https://vibeprompt.tech) - Free 10-step vibe coding workflow with 56 prompts, 17 deep-dive articles, 46 field-tested fixes, and an interactive AGENTS.md + PRD generator. Open source, MIT licensed.
+- [Wikivibe](https://wikivibe.ru/en/) - Practical knowledge base for AI-assisted development with guides, a glossary, jobs, and a public MCP endpoint.
 
 ## News and Social Media
 


### PR DESCRIPTION
Adds Wikivibe to Documentation for AI Coding as a practical AI-assisted development knowledge base with guides, glossary, jobs, and a public MCP endpoint.

Checked: link opens successfully at https://wikivibe.ru/en/.