### PR TITLE
Add ax telemetry tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 
 - [claude-dash](https://github.com/krabat-l/claude-dash) - Real-time statusline for Claude Code showing context, cost, quota, cache, tools, and git status.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - Local TUI for inspecting AI coding-agent session logs, usage, cost, latency, tool failures, diffs, and CI gates.
+- [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
 - [MUSE](https://github.com/myths-labs/muse) - Pure-Markdown memory OS for AI pair programming. Cross-conversation memory, 48 skills, role-based governance. Works with Claude Code, Cursor, Windsurf, OpenClaw, Gemini CLI, Codex CLI. Zero dependencies, MIT licensed.
 - [sober-coding](https://github.com/voidborne-d/sober-coding) - Post-generation audit for vibe-coded repos. 27 static checks across 7 dimensions (dead code, god files, duplicate blocks, deep nesting, empty except, dependency utilization…) with per-check fix suggestions and a CI mode that fails PRs on regressions. Language-agnostic, no LLM required.
 - [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime that delegates to Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid. Org chart view, schedules, runtime skills, persistent memory, sub-agent spawning. MCP-native (server and client). Electron desktop app, CLI, and Docker. MIT.


### PR DESCRIPTION
Adds ax to the Command Line Tools section.

Resource: https://github.com/Necmttn/ax

Why it is useful: ax gives local AI coding workflows telemetry for sessions, tool calls, cost, skills, and recall across Claude Code, Codex, Cursor, OpenCode, and Pi.

Checks run:

- `git diff --check`
- Added GitHub link returns 200
- `npx -y markdownlint-cli2 README.md` remains at the existing 51 baseline errors from the clean checkout

---

_Generated with [ax](https://github.com/Necmttn/ax)._