### PR TITLE
Add Vibe Coding Essentials to Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 - [Wikivibe](https://wikivibe.ru/en/) - Practical knowledge base for AI-assisted development with guides, a glossary, jobs, and a public MCP endpoint.
 
 - [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) - Local-first Loop Engineering workbench for writing verifiable AI coding-agent specs, verifier gates, rollback rules, and JSON reports.
+- [Vibe Coding Essentials](https://github.com/ashp15205/vibe-coding-essentials) - Anti-hallucination guardrails for 9 frameworks + a 4-mode workflow system (Economy / Builder / Maintainer / Architect) for AI-assisted development.
 
 ## News and Social Media
 


### PR DESCRIPTION
Hi! Adding Vibe Coding Essentials to the Documentation section. It provides explicit workflow boundaries (Builder vs Maintainer modes) and strict anti-hallucination guardrails, which solves the "AI rewrote 12 files for a 1-line bug" problem that a lot of vibe coders run into. Fits perfectly here. Let me know if you need any changes!