### PR TITLE
Add VibeKit.bot to Mobile-first Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 
 - [Vibecode](https://www.vibecodeapp.com/) - "the mobile app that builds mobile apps".
 - [Primio](https://primio.dev/) - chat-based builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.
+- [VibeKit.bot](https://vibekit.bot/) - build, deploy, and manage full-stack apps from your phone by chatting with a persistent AI agent that runs on hosted containers (not your device), so you get a live URL, a GitHub repo you own, and bring-your-own-key for Claude/OpenAI.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adding **VibeKit.bot** to the **Mobile-first Tools** section — it's squarely on-topic for this list and fills a gap next to Vibecode/Primio.

VibeKit lets you build, deploy, and manage full-stack apps entirely from your phone by chatting with a persistent AI agent. Unlike on-device builders, the agent runs on hosted containers (not your phone), so each app gets a live URL, a real GitHub repo you own, and bring-your-own-key support for Claude/OpenAI. Native iOS app + web dashboard.

- Site: https://vibekit.bot/
- Listed as **VibeKit.bot** to disambiguate from the unrelated `superagent-ai/vibekit` SDK.

Entry format matches the surrounding items (name + one-line description). Thanks for maintaining the list!