### PR TITLE
Add Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local, open-source macOS app for listening to Claude Code and Codex agents as they work, with Global Mix and blocker alerts.
 - [Agent Island](https://github.com/tristan666666/agent-island) - Open-source macOS notch companion for Claude Code and Codex long runs, with live session state, usage tracking, and optional auto-resume for trusted sessions.
 - [Agent Teams](https://github.com/777genius/agent-teams-ai) - Open-source desktop app for autonomous AI coding teams across Claude, Codex, and OpenCode. Give high-level commands while agents handle Kanban tasks, messaging, code review, logs, and approvals across 200+ models and 75+ LLM providers.
+- [Orca](https://onorca.dev) - An open-source desktop IDE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode), each in its own isolated git worktree, with built-in terminal and source control.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adds **Orca** to `Desktop Apps`.

Orca is an open-source (MIT) desktop IDE/ADE (macOS/Windows/Linux, plus a mobile companion) for running a fleet of parallel AI coding agents — Claude Code, Codex, Cursor, Gemini, OpenCode and others — each in its own isolated git worktree, with a built-in terminal, source control, and SSH.

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Placed in `Desktop Apps`, matching the existing format. Thanks!