### PR TITLE
Add DevIntern to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime that delegates to Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid. Org chart view, schedules, runtime skills, persistent memory, sub-agent spawning. MCP-native (server and client). Electron desktop app, CLI, and Docker. MIT.
 - [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge vault with bundled MCP server (`npx -y @swarmvaultai/cli mcp`). Compiles raw sources (notes, transcripts, exports, docs, code) into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. Cuts agent token usage by serving compact wiki summaries instead of full file reads. MIT.
 - [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Framework-agnostic local-first memory lifecycle for AI coding agents with Rust CLI, SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI.
+- [DevIntern](https://devintern.com/) - Picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions; the companion devpm tool creates codebase-grounded tickets from rough prompts. FSL-licensed, free for interactive use.
 
 ## Security & Pre-Deploy Checks
 


### PR DESCRIPTION
Adds [DevIntern](https://devintern.com/) ([repo](https://github.com/getdevintern/devintern), [docs](https://devintern.com/docs)) to the Command Line Tools section.

DevIntern picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), running on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions, and the companion devpm tool creates codebase-grounded tickets from rough prompts. FSL-1.1 licensed (source-available), free for interactive use.

I'm the author. Entry matches the existing format of the section.