### PR TITLE
Add nika to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 
 - [claude-dash](https://github.com/krabat-l/claude-dash) - Real-time statusline for Claude Code showing context, cost, quota, cache, tools, and git status.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - Local TUI for inspecting AI coding-agent session logs, usage, cost, latency, tool failures, diffs, and CI gates.
+- [nika](https://github.com/supernovae-st/nika) - Workflow engine for AI: capture repeatable vibe-coded tasks as .nika.yaml files, statically checked before execution (schema, permits, cost), with tamper-evident traces after.
 - [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
 - [MUSE](https://github.com/myths-labs/muse) - Pure-Markdown memory OS for AI pair programming. Cross-conversation memory, 48 skills, role-based governance. Works with Claude Code, Cursor, Windsurf, OpenClaw, Gemini CLI, Codex CLI. Zero dependencies, MIT licensed.
 - [sober-coding](https://github.com/voidborne-d/sober-coding) - Post-generation audit for vibe-coded repos. 27 static checks across 7 dimensions (dead code, god files, duplicate blocks, deep nesting, empty except, dependency utilization…) with per-check fix suggestions and a CI mode that fails PRs on regressions. Language-agnostic, no LLM required.


### PR DESCRIPTION
One line in Command Line Tools (house format, agenttrace neighborhood). nika is an open-source (AGPL, Rust) workflow engine for AI: the loop where you capture a repeatable vibe-coded task as a .nika.yaml file, statically check it before execution (schema, permits, cost floor), and keep tamper-evident traces after — so the automation an agent writes stays auditable and replayable. Local-first (Ollama/llama.cpp/vLLM, offline mock with zero keys). Disclosure: I am the nika author (first-party submission).