### PR TITLE
Add UIZZE anti-slop workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 
 - [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) - Local-first Loop Engineering workbench for writing verifiable AI coding-agent specs, verifier gates, rollback rules, and JSON reports.
 - [Vibe Coding Essentials](https://github.com/ashp15205/vibe-coding-essentials) - Anti-hallucination guardrails for 9 frameworks + a 4-mode workflow system (Economy / Builder / Maintainer / Architect) for AI-assisted development.
+- [Fix AI UI Slop With Real UI Context](https://uizze.com/ai-ui-slop) - A three-step workflow for researching public UI references, giving coding agents UI context, and checking implementations with design-contract, validation, audit, and critique workflows.
 
 ## News and Social Media
 


### PR DESCRIPTION
## What changed

Added the existing UIZZE anti-slop workflow to **Documentation for AI Coding**.

## Why it fits

The guide gives people using coding agents a concrete three-step path: research public UI references, give the agent real UI context, then check the implementation with the documented design-contract, validation, audit, and critique workflows.

## Checks

- Confirmed no existing UIZZE, `uizze.com`, exact-URL, issue, or PR duplicate.
- Added one entry to the matching documentation category.
- Verified `https://uizze.com/ai-ui-slop` returns HTTP 200.
- Ran `git diff --check`; `README.md` is the only changed file.
