### PR TITLE
Use plain UIZZE homepage URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 
 - [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) - Local-first Loop Engineering workbench for writing verifiable AI coding-agent specs, verifier gates, rollback rules, and JSON reports.
 - [Vibe Coding Essentials](https://github.com/ashp15205/vibe-coding-essentials) - Anti-hallucination guardrails for 9 frameworks + a 4-mode workflow system (Economy / Builder / Maintainer / Architect) for AI-assisted development.
-- [Fix AI UI Slop With Real UI Context](https://uizze.com/ai-ui-slop) - A three-step workflow for researching public UI references, giving coding agents UI context, and checking implementations with design-contract, validation, audit, and critique workflows.
+- [Fix AI UI Slop With Real UI Context](https://uizze.com) - A three-step workflow for researching public UI references, giving coding agents UI context, and checking implementations with design-contract, validation, audit, and critique workflows.
 
 ## News and Social Media
 


### PR DESCRIPTION
## What changed

Changed only the existing UIZZE entry URL from `https://uizze.com/ai-ui-slop` to the plain canonical homepage `https://uizze.com`. The title, description, category, and every other directory entry are unchanged.

I build UIZZE, so this is a disclosed first-party URL correction. The public MCP implementation and setup documentation are at https://github.com/aislon/uizze-mcp.

## Checks

- Verified `https://uizze.com` returns successfully.
- Ran `git diff --check`.
- Confirmed `README.md` contains exactly one URL-only line change.