### PR TITLE
Add Check My Vibe to security and pre-deploy checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 AI-generated apps often ship with exposed secrets, open databases, or missing security headers. These tools help you catch issues before going live.
 
 - [agent-qa](https://github.com/vostride/agent-qa) - Self-improving QA agent for web and mobile apps. Write natural-language tests, retain run memory, and catch UI regressions before shipping.
+- [Check My Vibe](https://checkmyvibeapp.com/) - Free passive scan for AI-built websites that checks public security headers, exposed source maps, credential-shaped client strings, and common sensitive paths, plus a 36-point manual checklist.
 - [Vibeproof](https://vibeproof.sh/) - Instant security scan for vibe-coded apps (Lovable, Bolt, v0, Cursor). Paste a URL or a public GitHub repo to find exposed secrets, open Supabase/Firebase databases, leaked files, vulnerable libraries, and GDPR gaps. Free scan, no signup.
 - [Snyk](https://snyk.io/) - Free-tier developer security platform that scans your code, dependencies, and infrastructure-as-code for known vulnerabilities.
 - [Mozilla HTTP Observatory](https://developer.mozilla.org/en-US/observatory) - Free website scan that grades your security headers (CSP, HSTS, and more) and explains how to fix them.


### PR DESCRIPTION
Adds Check My Vibe to the Security & Pre-Deploy Checks section. It is a free, no-account passive scanner for public deployment signals and includes a separate 36-point manual checklist for controls that a public scan cannot verify.