### PR TITLE
Add Better Agent to Desktop Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local, open-source macOS app for listening to Claude Code and Codex agents as they work, with Global Mix and blocker alerts.
 - [Agent Island](https://github.com/tristan666666/agent-island) - Open-source status companion for Claude Code and Codex with live session state, your-turn alerts, and local monitoring on macOS and Windows.
 - [Agent Teams](https://github.com/777genius/agent-teams-ai) - Open-source desktop app for autonomous AI coding teams across Claude, Codex, and OpenCode. Give high-level commands while agents handle Kanban tasks, messaging, code review, logs, and approvals across 200+ models and 75+ LLM providers.
+- [Better Agent](https://github.com/ofekron/better-agent) - Local workspace for Claude, Codex, and Gemini sessions with parallel forks, delegation, persistent state, and restart recovery across browser, desktop, mobile, CLI, and SDK. Source-available for non-commercial use; commercial use requires permission.
 - [Orca](https://onorca.dev) - An open-source desktop IDE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode), each in its own isolated git worktree, with built-in terminal and source control.
 
 ## Plugins and Extensions


### PR DESCRIPTION
Adds Better Agent to **Desktop Apps** alongside the existing multi-agent coding workspaces.

Better Agent runs Claude, Codex, and Gemini sessions in one local workspace with parallel forks, delegation, persistent state, detached execution, and restart recovery. The entry also notes its browser, desktop, mobile, CLI, and SDK surfaces and explicitly states the non-commercial source-available license.

This is distinct from the existing entries through its multi-provider durable-session model and recovery across frontend/backend restarts.

Validation:
- `git diff --check`
- Verified the project URL
- Checked the README, issues, and pull requests for duplicates
- Confirmed current activity and public documentation

Disclosure: I maintain Better Agent. It is source-available and free for non-commercial use; commercial use requires separate permission.

AI-assistance disclosure: this submission was drafted by Codex under the maintainer’s authorization and reviewed in Better Agent.