### PR TITLE
Add Orkas to Desktop Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [Agent Teams](https://github.com/777genius/agent-teams-ai) - Open-source desktop app for autonomous AI coding teams across Claude, Codex, and OpenCode. Give high-level commands while agents handle Kanban tasks, messaging, code review, logs, and approvals across 200+ models and 75+ LLM providers.
 - [Better Agent](https://github.com/ofekron/better-agent) - Local workspace for Claude, Codex, and Gemini sessions with parallel forks, delegation, persistent state, and restart recovery across browser, desktop, mobile, CLI, and SDK. Source-available for non-commercial use; commercial use requires permission.
 - [Orca](https://onorca.dev) - An open-source desktop IDE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode), each in its own isolated git worktree, with built-in terminal and source control.
+- [Orkas](https://orkas.ai?source=gh_vibe) - Open-source, local-first desktop workspace that coordinates specialist agents and runs Claude Code, Codex, OpenCode, and Cline from one chat. [Source](https://github.com/Orkas-AI/Orkas)
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
## Summary\n\nAdd Orkas to Desktop Apps.\n\nOrkas is an open-source, local-first desktop workspace that coordinates specialist agents and runs Claude Code, Codex, OpenCode, and Cline from one chat.\n\nProject: https://github.com/Orkas-AI/Orkas\nWebsite: https://orkas.ai?source=gh_vibe