### PR TITLE
Add CUT3 to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Playcode](https://playcode.io/ai-website-builder) - AI website and app builder with visual editing, hosting, and custom domains.
 - [Vibe Coding Profiler](https://www.vibe-coding-profiler.com/) - Analyzes git history to reveal your AI-assisted engineering style and vibe coding persona.
 - [Roblox GUI Maker](https://robloxguimaker.dev/) - Generate Roblox Studio GUI layouts and Lua starter code from prompts.
+- [CUT3](https://cut3.ai) - vibe coding for video: describe an edit, an agent rewrites the timeline and hands it back as a diff you approve.
 
 ## Mobile-first Tools
 


### PR DESCRIPTION
Adds CUT3 to Browser-based Tools.

Same loop as the app builders already listed, applied to video instead of code: you describe the change in chat, an agent rewrites the timeline, and the edit comes back as a diff you approve or reject.

One entry, matching the existing format, direct link with no tracking parameters. It is live with a free tier.