### PR TITLE
Add THROUGHLINE to Documentation for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 - [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) - Local-first Loop Engineering workbench for writing verifiable AI coding-agent specs, verifier gates, rollback rules, and JSON reports.
 - [Vibe Coding Essentials](https://github.com/ashp15205/vibe-coding-essentials) - Anti-hallucination guardrails for 9 frameworks + a 4-mode workflow system (Economy / Builder / Maintainer / Architect) for AI-assisted development.
 - [Fix AI UI Slop With Real UI Context](https://uizze.com) - A three-step workflow for researching public UI references, giving coding agents UI context, and checking implementations with design-contract, validation, audit, and critique workflows.
+- [THROUGHLINE](https://github.com/hellomyoh/throughline) - Spec-driven development framework for coding agents, made of markdown and git with nothing to install. Personas debate each spec before code, and an append-only single source of truth keeps earlier decisions from drifting across sessions. Works with Claude Code, Codex, and Cursor. English and Korean, MIT.
 
 ## News and Social Media
 


### PR DESCRIPTION
Adds [THROUGHLINE](https://github.com/hellomyoh/throughline) to **Documentation for AI Coding**, next to entries like vibeprompt, Ariadne Loop, and Vibe Coding Essentials.

THROUGHLINE is a spec-driven development framework for AI coding agents, made of markdown and git with nothing to install. It targets the failure mode vibe coding runs into once a project outlives a single session: personas debate each spec before code is written, and an append-only single source of truth keeps earlier decisions from drifting as sessions accumulate.

Works with Claude Code, Codex, and Cursor. Documentation in English and Korean. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)