### PR TITLE
Add Blume

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 
 ## Desktop Apps
 
+- [Blume](https://blume.codes/) - Desktop sidecar that monitors coding-agent sessions, shows the rules, skills, and hooks shaping each run, tracks usage across Claude Code, Codex, Cursor, omp, and Pi, and keeps chat history local.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Open-source desktop app for running Claude Code, Codex CLI, Gemini CLI, and other terminal coding agents in parallel, with isolated git worktrees, terminal panes, diff review, and merge controls.
 - [PinkCode](https://github.com/3xian/PinkCode) - Open-source desktop GUI for running multiple Grok Build coding-agent sessions in parallel, with live activity, usage, file-change, and permission views.


### PR DESCRIPTION
## What changed

Added Blume to the Desktop Apps section.

Blume is a desktop sidecar for coding agents. It monitors agent sessions, surfaces the rules, skills, and hooks shaping each run, tracks usage, and keeps conversation history under local control.

## Disclosure

Blume is our own product, and we use it ourselves.