### PR TITLE
Add WeInc to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [Vibecode](https://www.vibecodeapp.com/) - "the mobile app that builds mobile apps".
 - [Primio](https://primio.dev/) - chat-based builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.
 - [VibeKit.bot](https://vibekit.bot/) - build, deploy, and manage full-stack apps from your phone by chatting with a persistent AI agent that runs on hosted containers (not your device), so you get a live URL, a GitHub repo you own, and bring-your-own-key for Claude/OpenAI.
+- [WeInc](https://we.inc/) - AI website builder that generates complete hosted production sites (React) from prompts, with flat pricing and white-label for agencies.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Hi! This adds [WeInc](https://we.inc) to the Browser-based Tools section, following the existing entry format.

WeInc is an AI website builder that turns prompts into complete, hosted production sites (React), with flat pricing and white-label support for agencies.

We also maintain [awesome-ai-website-builders](https://github.com/umairalisadaqat/awesome-ai-website-builders), a curated comparison of tools in the same space. Happy to adjust wording or placement if you prefer. Thanks for maintaining this list!