### PR TITLE
Add BitFun to Desktop Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 
 ## Desktop Apps
 
+- [BitFun](https://github.com/GCWing/BitFun) - Open-source cross-platform desktop AI agent that plans, edits, tests, and commits in real Git repositories, while also handling browser, terminal, desktop-app, and remote-workspace tasks through MCP, Skills, Hooks, and task-specific Mini Apps.
 - [Blume](https://blume.codes/) - Desktop sidecar that monitors coding-agent sessions, shows the rules, skills, and hooks shaping each run, tracks usage across Claude Code, Codex, Cursor, omp, and Pi, and keeps chat history local.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Open-source desktop app for running Claude Code, Codex CLI, Gemini CLI, and other terminal coding agents in parallel, with isolated git worktrees, terminal panes, diff review, and merge controls.


### PR DESCRIPTION
## What this adds

Adds [BitFun](https://github.com/GCWing/BitFun) to **Desktop Apps**.

BitFun is an MIT-licensed, cross-platform desktop AI agent with a Rust runtime. It works in real Git repositories and can also operate browsers, terminals, desktop applications, filesystems, and remote workspaces. MCP, Skills, Hooks, custom Agents, and task-specific Mini Apps provide extension points.

## Why it fits

The entry describes the downloadable macOS, Windows, and Linux desktop product and its coding-agent workflow, matching the other local desktop tools in this section.

## Disclosure

This is a project self-submission made on behalf of BitFun.

## Verification

- Searched the current README and public PR/issue history for duplicates
- Linked the canonical source repository
- Kept the change to one README entry
