### PR TITLE
Add BuildMuse as a visual reference resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 - [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) - Local-first Loop Engineering workbench for writing verifiable AI coding-agent specs, verifier gates, rollback rules, and JSON reports.
 - [Vibe Coding Essentials](https://github.com/ashp15205/vibe-coding-essentials) - Anti-hallucination guardrails for 9 frameworks + a 4-mode workflow system (Economy / Builder / Maintainer / Architect) for AI-assisted development.
 - [Fix AI UI Slop With Real UI Context](https://uizze.com) - A three-step workflow for researching public UI references, giving coding agents UI context, and checking implementations with design-contract, validation, audit, and critique workflows.
+- [BuildMuse](https://buildmuse.design/) - Curated interface videos, app screens, websites, motion references, and frontend effects for giving vibe-coding agents clearer visual direction.
 - [THROUGHLINE](https://github.com/hellomyoh/throughline) - Spec-driven development framework for coding agents, made of markdown and git with nothing to install. Personas debate each spec before code, and an append-only single source of truth keeps earlier decisions from drifting across sessions. Works with Claude Code, Codex, and Cursor. English and Korean, MIT.
 - [anti-slop-website-prompts](https://github.com/mah-claude/anti-slop-website-prompts) - 15 free art-directed website build-prompts plus an anti-slop design skill for Lovable, Bolt, v0, Cursor, and Claude Code.
 - [Undercroft](https://github.com/latticeworklabs-eng/undercroft) - Open-source CLAUDE.md operations contract that turns Claude Code into the maintainer of a plain-Markdown personal wiki: three-layer raw/wiki/schema architecture, checklist-driven ingestion, append-only changelog, and a worked example vault. Obsidian-friendly and portable to other agent CLIs via an AGENTS.md rename. MIT.
@@ -147,4 +148,3 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 - [Vibe Coding - Where Everyone Can ‘Speak’ Computer Programming - The New Stack](https://thenewstack.io/vibe-coding-where-everyone-can-speak-computer-programming/)
 - [A.I. and Vibecoding Helped Me to Create My Own Software - The New York Times](https://www.nytimes.com/2025/02/27/technology/personaltech/vibecoding-ai-software-programming.html)
 - [/r/vibecoding](https://www.reddit.com/r/vibecoding/)
-


### PR DESCRIPTION
## What this adds\n\nAdds [BuildMuse](https://buildmuse.design/) to the AI-coding documentation/resources section.\n\n## Why it belongs\n\nBuildMuse is a curated library of interface videos, app screens, websites, motion references, and frontend effects. It helps vibe coders give AI coding agents concrete visual direction instead of relying on vague prompts.\n\n- Link checked and currently returns HTTP 200\n- Existing list checked for duplicates\n- Description follows the list's one-line format