### PR TITLE
Add Sillage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [VibeKit.bot](https://vibekit.bot/) - build, deploy, and manage full-stack apps from your phone by chatting with a persistent AI agent that runs on hosted containers (not your device), so you get a live URL, a GitHub repo you own, and bring-your-own-key for Claude/OpenAI.
 - [WeInc](https://we.inc/) - AI website builder that generates complete hosted production sites (React) from prompts, with flat pricing and white-label for agencies.
 - [Mobile SSH](https://mobile-ssh.github.io) - drive Claude Code and Codex sessions running on your own servers from Android or iOS, with an alert the moment an agent blocks on input and one tap to answer it, plus tmux, Zellij and herdr session managers.
+- [Sillage](https://github.com/MarlBurroW/sillage) - self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (the official agent harnesses, without a terminal), with sessions that outlive the client, full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds Sillage to the Mobile-first Tools section.

Disclosure: I am the author of Sillage.

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (the official agent harnesses, without a terminal). Sessions outlive the client (server-side event journal), full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), git worktrees, a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container on port 7317.

Repo: https://github.com/MarlBurroW/sillage