### PR TITLE
Add Mobile SSH to Mobile-first Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - [Primio](https://primio.dev/) - chat-based builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.
 - [VibeKit.bot](https://vibekit.bot/) - build, deploy, and manage full-stack apps from your phone by chatting with a persistent AI agent that runs on hosted containers (not your device), so you get a live URL, a GitHub repo you own, and bring-your-own-key for Claude/OpenAI.
 - [WeInc](https://we.inc/) - AI website builder that generates complete hosted production sites (React) from prompts, with flat pricing and white-label for agencies.
+- [Mobile SSH](https://mobile-ssh.github.io) - drive Claude Code and Codex sessions running on your own servers from Android or iOS, with an alert the moment an agent blocks on input and one tap to answer it, plus tmux, Zellij and herdr session managers.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds **Mobile SSH** to `## Mobile-first Tools`.

The existing entries in that section build apps from a phone. This one is the other half of mobile-first: it lets you keep an agent moving when you are away from the desk.

You run Claude Code or Codex on your own server inside tmux, Zellij or herdr. Mobile SSH connects over plain SSH — no relay, no account, no cloud — and watches the panes. The moment an agent blocks on a prompt, the pane goes amber, a toolbar badge counts how many are waiting, and you get a notification. Tap the agent, answer, and it carries on. Sessions survive roaming between Wi-Fi and cellular, because a saved server can hold several addresses and dials whichever answers.

Website and docs: https://mobile-ssh.github.io

Two things worth being straight about: it is closed source, and it is currently in beta (Google Play closed test on Android, TestFlight on iOS), so the link is the project site rather than a store listing. Happy to close this and resubmit once the public listings are live if you would rather wait for that.

Disclosure: I am the author.

One line added to the bottom of Mobile-first Tools, in the existing format. Nothing else touched — I left the Contents TOC alone even though it is missing a couple of section anchors, since that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
