### PR TITLE
Add d1v to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 - [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Framework-agnostic local-first memory lifecycle for AI coding agents with Rust CLI, SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI.
 - [DevIntern](https://devintern.com/) - Picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions; the companion devpm tool creates codebase-grounded tickets from rough prompts. FSL-licensed, free for interactive use.
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - Diff your AI agent's behavior between two runs: tool calls, args, cost, latency, and outcome flips, with flake detection and CI exit codes. MIT, on npm as whatbroke-cli.
+- [d1v](https://github.com/d1vai/d1v-cli) - CLI deployment workflow for AI-built web projects with verified previews and production releases requiring explicit confirmation. MIT.
 
 ## Security & Pre-Deploy Checks
 


### PR DESCRIPTION
## What this adds

Adds [d1v](https://github.com/d1vai/d1v-cli) to **Command Line Tools**.

## Why it fits

d1v is a CLI deployment workflow for AI-built web projects. It waits for a verified preview deployment and requires explicit user confirmation before a production release, making the environment boundary visible in the normal CLI flow.

## Disclosure

This is a project self-submission made on behalf of d1v. The linked source is public and MIT-licensed.

## Verification

- searched the current README and PR history for an existing d1v entry
- linked the canonical project repository
- kept the change to one README entry at the bottom of the existing section
- ran `git diff --check`

No target-project dependencies, builds, or tests were run for this documentation-only change.