### PR TITLE
Add liyupi/ai-guide to Documentation for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ AI-generated apps often ship with exposed secrets, open databases, or missing se
 
 - [Vibe Coding UI Specification](https://horizonx.so/resources/vibe-coding-ui-specification) - Free, MIT-licensed interface contract for AI-assisted React and Tailwind work, covering design tokens, component states, responsive behavior, WCAG 2.2 AA, reduced motion, production gates, and reusable YAML.
 - [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) - MIT-licensed five-step workflow (deep research, PRD, tech design, AGENTS.md, build) with copy-paste prompts and an `npx vibeworkflow` CLI that interviews you and writes the planning docs and agent files.
+- [liyupi/ai-guide](https://github.com/liyupi/ai-guide) - Free Chinese vibe coding handbook covering tool selection, prompting and context management, dozens of end-to-end project builds, and shipping to production. English and Traditional Chinese translations included. [Online version](https://ai.codefather.cn/vibe).
 
 ## News and Social Media
 


### PR DESCRIPTION
## Resource

[liyupi/ai-guide](https://github.com/liyupi/ai-guide) — online version: https://ai.codefather.cn/vibe

## Why it fits

A free, open-source, book-length Chinese handbook on vibe coding, written by a former Tencent full-stack engineer. The list already has one Chinese entry in this section; this one is complementary rather than overlapping, because it goes past tool usage into building and shipping real products:

- Tool selection across AI IDEs, CLI agents, IDE plugins, and no-code/agent platforms
- Prompting, context management, hallucination handling, and code-quality practices
- Dozens of end-to-end project walkthroughs — utilities, full-stack apps, agents, and mini-programs
- Shipping and monetization: deployment, SEO, analytics, and growth
- Reference material: AI coding concept glossary, resource directory, and FAQ

Fully free with no paywall, actively updated, and available in Simplified Chinese, Traditional Chinese, and English.

Made with [Cursor](https://cursor.com)