### PR TITLE
Add Vicoa to IDEs and Code Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Windsurf Editor by Codeium](https://codeium.com/windsurf) - Agentic IDE, "where the work of developers and AI truly flow together, allowing for a coding experience that feels like literal magic".
 - 🔥 [Cursor](https://www.cursor.com/) - AI Code Editor, "the best way to code with AI".
 - [Zed](https://zed.dev/) - Code editor designed for high-performance collaboration with humans and AI.
+- [Vicoa](https://vicoa.ai) - Agentic IDE, AI orchestrator for running Claude Code, Codex, OpenCode, Gemini, Cursor, GitHub Copilot, Kimi, and Hermes from desktop, web, or mobile: real-time sync, parallel git worktrees, and push notifications, with a Python/FastAPI backend, Next.js + Electron desktop, and Flutter mobile. [Source](https://github.com/vicoa-ai/vicoa)
 
 ## Desktop Apps
 


### PR DESCRIPTION
## What

Adds [Vicoa](https://vicoa.ai) ([source](https://github.com/vicoa-ai/vicoa)) to the IDEs and Code Editors section, alongside Windsurf, Cursor, and Zed.

## About the project

Vicoa is an open-source, self-hostable agentic IDE and AI orchestrator for running coding agents (Claude Code, Codex, OpenCode, Gemini, Cursor, GitHub Copilot, Kimi, Hermes) from desktop, web, or mobile, with real-time sync, parallel git worktrees, and push notifications. Stack: Python/FastAPI backend, Next.js web + Electron desktop, Flutter mobile.

It's a young project (~30 stars) but functional and actively developed, flagging that upfront in case size/maturity matters for inclusion.

## Checklist

- [x] Live URL (https://vicoa.ai and https://github.com/vicoa-ai/vicoa)
- [x] One entry added, matches existing formatting in the section
- [x] Not already listed in the README