### PR TITLE
Add YYLO to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [DevIntern](https://devintern.com/) - Picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions; the companion devpm tool creates codebase-grounded tickets from rough prompts. FSL-licensed, free for interactive use.
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - Diff your AI agent's behavior between two runs: tool calls, args, cost, latency, and outcome flips, with flake detection and CI exit codes. MIT, on npm as whatbroke-cli.
 - [d1v](https://github.com/d1vai/d1v-cli) - CLI deployment workflow for AI-built web projects with verified previews and production releases requiring explicit confirmation. MIT.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes: typed task, validation, merge, and release-readiness boundaries, with each task on a dedicated branch/worktree and a merge queue that owns risk-based review. MIT, on npm as @yylo/cli.
 
 ## Security & Pre-Deploy Checks
 


### PR DESCRIPTION
## What this adds

Adds [YYLO](https://github.com/yylo-dev/yylo) to **Command Line Tools**.

## Why it fits

YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. Each task runs in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries, and a merge queue owns risk-based review — the same "coordinate coding agents from the terminal" territory as the section's existing entries (nika, MyCoder.ai, SwarmClaw).

## Disclosure

I am on the team that builds YYLO; this is a self-submission. The linked source is public and MIT-licensed. The PR was prepared with an AI coding agent following the list's existing entry format; the content was reviewed by me.

## Verification

- searched the current README and PR history for an existing YYLO entry (none found)
- linked the canonical project repository (yylo-dev/yylo, npm `@yylo/cli`, daily commits since Jan 2026)
- kept the change to one README entry at the bottom of the existing section, matching the merged d1v/whatbroke entry shape
- ran `git diff --check`

No target-project dependencies, builds, or tests were run for this documentation-only change.
